### PR TITLE
Refactor json api query (order by/page)

### DIFF
--- a/backend/app/domain/entity/query_base.go
+++ b/backend/app/domain/entity/query_base.go
@@ -39,12 +39,12 @@ func (q *QueryBase) SetPage(param map[string]string) {
 }
 
 // GetLimit pagenation limit
-func (q *QueryBase) GetLimit() int {
+func (q QueryBase) GetLimit() int {
 	return q.Page.Limit
 }
 
 // GetOffset pagenation offset
-func (q *QueryBase) GetOffset() int {
+func (q QueryBase) GetOffset() int {
 	return q.Page.Offset
 }
 
@@ -59,10 +59,23 @@ func (q *QueryBase) SetSort(sort []string) {
 	q.Sort = items
 }
 
-// ToOrderBy constructs ORDER BY clause
-func (s sortItem) ToOrderBy() string {
+// IsOrderByNeeded necessary
+func (q QueryBase) IsOrderByNeeded() bool {
+	return len(q.Sort) > 0
+}
+
+func (s sortItem) toOrderBy() string {
 	if strings.HasPrefix(string(s), "-") {
 		return fmt.Sprintf("%s DESC", s[1:])
 	}
 	return string(s)
+}
+
+// ToOrderBy constructs ORDER BY clause
+func (q QueryBase) ToOrderBy() string {
+	clauses := make([]string, len(q.Sort))
+	for i := 0; i < len(q.Sort); i++ {
+		clauses[i] = q.Sort[i].toOrderBy()
+	}
+	return strings.Join(clauses, ",")
 }

--- a/backend/app/domain/entity/sample.go
+++ b/backend/app/domain/entity/sample.go
@@ -24,8 +24,6 @@ type SampleQuery struct {
 	QueryBase
 }
 
-// TODO: define the method to construct query to SampleQuery
-
 // Validate with validator v10
 func (s *Sample) Validate() error {
 	validate := validator.New()

--- a/backend/app/interface/api/handler/sample_handler.go
+++ b/backend/app/interface/api/handler/sample_handler.go
@@ -30,18 +30,15 @@ func (hdl *SampleHandler) Index(ctx *gin.Context) {
 		hdl.SetError(ctx, err)
 	}()
 
-	// TODO: refactor, put the login inside presenter
-	var search dto.JSONAPIQuery
-	if err = ctx.BindQuery(&search); err != nil {
+	q, err := dto.NewJSONAPIQueryFromContext(ctx)
+	if err != nil {
 		return
 	}
-	search.Filter = ctx.QueryMap("filter")
-	search.Page = ctx.QueryMap("page")
 
 	claims := hdl.JWTClaims(ctx)
 
 	suCase := registry.InitializeSampleUsecase()
-	samples, err := suCase.List(claims.UserID, search)
+	samples, err := suCase.List(claims.UserID, q)
 	if err != nil {
 		return
 	}

--- a/backend/app/interface/persistence/mysql/sample_repository.go
+++ b/backend/app/interface/persistence/mysql/sample_repository.go
@@ -22,7 +22,6 @@ func (r *SampleRepository) FindAll(userID uint64, query *entity.SampleQuery) ([]
 
 	db := r.DB.Where(&entity.Sample{UserID: userID})
 
-	// TODO: goroutine in pararell
 	// TODO: define each type for query
 	if query.Title != "" {
 		db = db.Where("title LIKE ?", "%"+query.Title+"%")
@@ -31,10 +30,8 @@ func (r *SampleRepository) FindAll(userID uint64, query *entity.SampleQuery) ([]
 		db = db.Where("content LIKE ?", "%"+query.Content+"%")
 	}
 
-	// TODO: move this logic to definedtype
-	for i := 0; i < len(query.Sort); i++ {
-		s := query.Sort[i]
-		db = db.Order(s.ToOrderBy())
+	if query.IsOrderByNeeded() {
+		db = db.Order(query.ToOrderBy())
 	}
 
 	err := db.Limit(query.GetLimit()).Offset(query.GetOffset()).Find(&samples).Error

--- a/backend/app/usecase/dto/json_api_query.go
+++ b/backend/app/usecase/dto/json_api_query.go
@@ -1,6 +1,8 @@
 package dto
 
 import (
+	"strings"
+
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -9,6 +11,25 @@ type JSONAPIQuery struct {
 	Sort   []string          `form:"sort"`
 	Filter map[string]string `form:"filter"`
 	Page   map[string]string `form:"page"`
+}
+
+type ginContext interface {
+	Query(key string) string
+	QueryMap(key string) map[string]string
+}
+
+// NewJSONAPIQueryFromContext constructor
+func NewJSONAPIQueryFromContext(ctx ginContext) (*JSONAPIQuery, error) {
+	var q JSONAPIQuery
+
+	sort := ctx.Query("sort")
+	if sort != "" {
+		q.Sort = strings.Split(sort, ",")
+	}
+
+	q.Filter = ctx.QueryMap("filter")
+	q.Page = ctx.QueryMap("page")
+	return &q, nil
 }
 
 type queryBase interface {

--- a/backend/app/usecase/sample_usecase.go
+++ b/backend/app/usecase/sample_usecase.go
@@ -32,14 +32,14 @@ func NewSampleUsecase(
 }
 
 // List list sample
-func (s *SampleUsecase) List(userID uint64, search dto.JSONAPIQuery) ([]entity.Sample, error) {
-	var query entity.SampleQuery
-	err := search.Bind(&query)
+func (s *SampleUsecase) List(userID uint64, query *dto.JSONAPIQuery) ([]entity.Sample, error) {
+	var enQuery entity.SampleQuery
+	err := query.Bind(&enQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	samples, err := s.repo.FindAll(userID, &query)
+	samples, err := s.repo.FindAll(userID, &enQuery)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
FilterのRefactor戦略メモ
- dtoのtypeは `map[string][string]string` で定義する
  - 2つ目の [string]には `LIKE` とか `>`, `NULL` とかそういうSQLの演算子をあらわすものが入る予定
- SampleQueryのFieldは独自に定義したもの
  - たぶん 演算子と値を持つ struct だと思われ
- SQLのwhereを組み立てるのもどこに抽象化できるようにする
