### PR TITLE
accept conditions for query

### DIFF
--- a/backend/app/domain/entity/query_base.go
+++ b/backend/app/domain/entity/query_base.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"gorm.io/gorm"
 )
 
 const (
@@ -12,10 +14,131 @@ const (
 
 // QueryBase for json api filters
 type QueryBase struct {
-	Page page
-	Sort []sortItem
+	Filters map[string]filter
+	Page    page
+	Sort    []sortItem
 }
 
+// ========== Filters ==========
+type filter struct {
+	Condition condition
+	Value     value
+}
+
+type condition string
+type value interface{}
+
+const (
+	likeClause  = condition("LIKE ?")
+	nlikeClause = condition("NOT LIKE ?")
+	eqClause    = condition("= ?")
+	neClause    = condition("<> ?")
+	geClause    = condition(">= ?")
+	gtClause    = condition("> ?")
+	leClause    = condition("<=")
+	ltClause    = condition("<")
+	inClause    = condition("IN ?")
+	ninClause   = condition("NOT IN ?")
+	btwClause   = condition("BETWEEN ? AND ?")
+)
+
+var conditions = map[string]condition{
+	"like":  likeClause,
+	"nlike": nlikeClause,
+	"eq":    eqClause,
+	"ne":    neClause,
+	"ge":    geClause,
+	"gt":    gtClause,
+	"le":    leClause,
+	"lt":    ltClause,
+	"in":    inClause,
+	"nin":   ninClause,
+	"btw":   btwClause,
+}
+
+func (c condition) sqlValue(v string) (value /*SQL clause*/, bool /*ok*/) {
+	if c == btwClause {
+		values := strings.Split(v, ",")
+		if len(values) != 2 || values[0] == "" || values[1] == "" {
+			return "", false
+		}
+		return values /*[]string, length == 2*/, true
+	}
+
+	if c == inClause || c == ninClause {
+		values := strings.Split(v, ",")
+
+		var cleaned []string
+		for _, v := range values {
+			if v != "" {
+				cleaned = append(cleaned, v)
+			}
+		}
+
+		if len(cleaned) == 0 {
+			return value(""), false
+		}
+		return cleaned /*[]string*/, true
+	}
+
+	if c == likeClause || c == nlikeClause {
+		return "%" + v + "%", true
+	}
+	return v, true
+}
+
+// SetFilters converts map[string]string to []filter
+func (q *QueryBase) SetFilters(params map[string]string) {
+	result := make(map[string]filter)
+
+	for k, v := range params {
+		f := strings.SplitN(v, ":", 2)
+		if len(f) != 2 || f[0] == "" || f[1] == "" {
+			continue
+		}
+
+		condition, ok := conditions[f[0]]
+		if !ok {
+			continue
+		}
+
+		sqlv, ok := condition.sqlValue(f[1])
+		if !ok {
+			continue
+		}
+
+		result[k] = filter{Condition: condition, Value: sqlv}
+	}
+
+	q.Filters = result
+}
+
+// FIXME: shouldn't use gorm in entity for the point of clean architecture
+// It may be one option to move these logics to repository or pkg
+type gormDB interface {
+	Where(query interface{}, args ...interface{}) (tx *gorm.DB)
+}
+
+// AddClause add conditions
+// TODO: enable to convert other types, int, time...
+func (q *QueryBase) AddClause(column string, db gormDB) {
+	f, ok := q.Filters[column]
+	if !ok {
+		return
+	}
+
+	if f.Condition == btwClause {
+		db.Where(
+			column+" "+string(f.Condition),
+			f.Value.([]string)[0],
+			f.Value.([]string)[1],
+		)
+		return
+	}
+	db.Where(column+" "+string(f.Condition), f.Value)
+}
+
+// ========== Page ==========
 type page struct {
 	Offset int
 	Limit  int
@@ -48,6 +171,7 @@ func (q QueryBase) GetOffset() int {
 	return q.Page.Offset
 }
 
+// ========== Sort ==========
 type sortItem string
 
 // SetSort setter for Sort
@@ -64,6 +188,7 @@ func (q QueryBase) IsOrderByNeeded() bool {
 	return len(q.Sort) > 0
 }
 
+// TODO: prevent from SQL Injection
 func (s sortItem) toOrderBy() string {
 	if strings.HasPrefix(string(s), "-") {
 		return fmt.Sprintf("%s DESC", s[1:])

--- a/backend/app/domain/entity/sample.go
+++ b/backend/app/domain/entity/sample.go
@@ -18,8 +18,8 @@ type Sample struct {
 
 // SampleQuery sql filter
 type SampleQuery struct {
-	Title   string
-	Content string
+	Title   string `column:"title"`
+	Content string `column:"content"`
 
 	QueryBase
 }

--- a/backend/app/interface/persistence/mysql/sample_repository.go
+++ b/backend/app/interface/persistence/mysql/sample_repository.go
@@ -22,16 +22,11 @@ func (r *SampleRepository) FindAll(userID uint64, query *entity.SampleQuery) ([]
 
 	db := r.DB.Where(&entity.Sample{UserID: userID})
 
-	// TODO: define each type for query
-	if query.Title != "" {
-		db = db.Where("title LIKE ?", "%"+query.Title+"%")
-	}
-	if query.Content != "" {
-		db = db.Where("content LIKE ?", "%"+query.Content+"%")
-	}
+	query.AddClause("title", db)
+	query.AddClause("content", db)
 
 	if query.IsOrderByNeeded() {
-		db = db.Order(query.ToOrderBy())
+		db.Order(query.ToOrderBy())
 	}
 
 	err := db.Limit(query.GetLimit()).Offset(query.GetOffset()).Find(&samples).Error

--- a/backend/app/usecase/dto/json_api_query.go
+++ b/backend/app/usecase/dto/json_api_query.go
@@ -33,6 +33,7 @@ func NewJSONAPIQueryFromContext(ctx ginContext) (*JSONAPIQuery, error) {
 }
 
 type queryBase interface {
+	SetFilters(filter map[string]string)
 	SetPage(page map[string]string)
 	SetSort(sort []string)
 }
@@ -44,6 +45,7 @@ func (q JSONAPIQuery) Bind(query queryBase) error {
 		return err
 	}
 
+	query.SetFilters(q.Filter)
 	query.SetPage(q.Page)
 	query.SetSort(q.Sort)
 	return nil

--- a/frontend/src/api/app/sample.ts
+++ b/frontend/src/api/app/sample.ts
@@ -5,7 +5,7 @@ import { TypeSample } from "constants/type";
 export const list = (): Promise<AxiosResponse<any>> => {
   return API.get("/samples");
 };
-// samples?sort=title,-content&filter[title]=title&filter[content]=content&page[limit]=20&page[offset]=1
+// samples?sort=title,-content&filter[title]=eq:title&filter[content]=in:a,b&page[limit]=20&page[offset]=1
 
 export const get = (id: number): Promise<AxiosResponse<any>> => {
   return API.get(`/samples/${id}`);


### PR DESCRIPTION
いろいろTODOがある
- sortでSQLインジェクション防ぐ
- filterで一つのfileldに対して複数のconditionを受け付けるようにする
 - 例えば、 like %hoge% AND NOT LIKE %fuga%みたいな
- gormとmysqlをentityで意識するのは良くない（clean architectureの観点で）
- string以外のタイプもクエリできるようにする
 - time, intとか